### PR TITLE
BTL 3.0 usnic update

### DIFF
--- a/opal/mca/btl/btl.h
+++ b/opal/mca/btl/btl.h
@@ -6,19 +6,19 @@
  * Copyright (c) 2004-2008 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart, 
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2015 Los Alamos National Security, LLC.  All rights
- *                         reserved. 
+ *                         reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2012-2013 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
- * 
+ *
  * Additional copyrights may follow
- * 
+ *
  * $HEADER$
  */
 /**
@@ -76,8 +76,8 @@
  * TCP               0       Selected based on network reachability
  * TCP               0       Selected based on network reachability
  *
- * When mca_btl_base_add_proc_fn_t() is called on a  BTL module, the BTL 
- * will populate an OUT variable with mca_btl_base_endpoint_t pointers. 
+ * When mca_btl_base_add_proc_fn_t() is called on a  BTL module, the BTL
+ * will populate an OUT variable with mca_btl_base_endpoint_t pointers.
  * Each pointer is treated as an opaque handle by the upper layer and is
  * returned to the BTL on subsequent data transfer calls to the
  * corresponding destination process.  The actual contents of the
@@ -133,7 +133,7 @@ struct mca_btl_base_module_t;
 struct mca_btl_base_endpoint_t;
 struct mca_btl_base_descriptor_t;
 struct mca_mpool_base_resources_t;
-struct opal_proc_t; 
+struct opal_proc_t;
 
 /**
  * Opaque registration handle for executing RDMA and atomic
@@ -303,9 +303,9 @@ typedef enum mca_btl_base_atomic_op_t mca_btl_base_atomic_op_t;
 
 /**
  * Asynchronous callback function on completion of an operation.
- * Completion Semantics: The descriptor can be reused or returned to the 
+ * Completion Semantics: The descriptor can be reused or returned to the
  *  BTL via mca_btl_base_module_free_fn_t. The operation has been queued to
- *  the network device or will otherwise make asynchronous progress without 
+ *  the network device or will otherwise make asynchronous progress without
  *  subsequent calls to btl_progress.
  *
  * @param[IN] module      the BTL module
@@ -346,7 +346,7 @@ typedef void (*mca_btl_base_rdma_completion_fn_t)(
 
 
 /**
- * Describes a region/segment of memory that is addressable 
+ * Describes a region/segment of memory that is addressable
  * by an BTL.
  *
  * Note: In many cases the alloc and prepare methods of BTLs
@@ -364,7 +364,7 @@ typedef void (*mca_btl_base_rdma_completion_fn_t)(
 
 struct mca_btl_base_segment_t {
     /** Address of the memory */
-    opal_ptr_t seg_addr;        
+    opal_ptr_t seg_addr;
      /** Length in bytes */
     uint64_t   seg_len;
 };
@@ -380,21 +380,21 @@ typedef struct mca_btl_base_segment_t mca_btl_base_segment_t;
  */
 
 struct mca_btl_base_descriptor_t {
-    ompi_free_list_item_t super;  
+    ompi_free_list_item_t super;
     mca_btl_base_segment_t *des_segments;     /**< local segments */
     size_t des_segment_count;                 /**< number of local segments */
-    mca_btl_base_completion_fn_t des_cbfunc;  /**< local callback function */ 
+    mca_btl_base_completion_fn_t des_cbfunc;  /**< local callback function */
     void* des_cbdata;                         /**< opaque callback data */
     void* des_context;                        /**< more opaque callback data */
     uint32_t des_flags;                       /**< hints to BTL */
-    /** order value, this is only 
-        valid in the local completion callback 
-        and may be used in subsequent calls to 
+    /** order value, this is only
+        valid in the local completion callback
+        and may be used in subsequent calls to
         btl_alloc, btl_prepare_src to request
-        a descriptor that will be ordered w.r.t. 
+        a descriptor that will be ordered w.r.t.
         this descriptor
     */
-    uint8_t order;                            
+    uint8_t order;
 };
 typedef struct mca_btl_base_descriptor_t mca_btl_base_descriptor_t;
 
@@ -441,13 +441,13 @@ OPAL_DECLSPEC OBJ_CLASS_DECLARATION(mca_btl_base_descriptor_t);
  */
 #define MCA_BTL_REG_HANDLE_MAX_SIZE 256
 
-/* 
- *  BTL base header, stores the tag at a minimum 
- */ 
-struct mca_btl_base_header_t{ 
-    mca_btl_base_tag_t tag; 
-}; 
-typedef struct mca_btl_base_header_t mca_btl_base_header_t; 
+/*
+ *  BTL base header, stores the tag at a minimum
+ */
+struct mca_btl_base_header_t{
+    mca_btl_base_tag_t tag;
+};
+typedef struct mca_btl_base_header_t mca_btl_base_header_t;
 
 #define MCA_BTL_BASE_HEADER_HTON(hdr)
 #define MCA_BTL_BASE_HEADER_NTOH(hdr)
@@ -471,19 +471,19 @@ typedef struct mca_btl_base_header_t mca_btl_base_header_t;
  * indicates whether multiple threads may invoke this component
  * simultaneously or not.
  *
- * @return Array of pointers to BTL modules, or NULL if the transport  
+ * @return Array of pointers to BTL modules, or NULL if the transport
  *         is not available.
  *
  * During component initialization, the BTL component should discover
  * the physical devices that are available for the given transport,
- * and create a BTL module to represent each device. Any addressing 
- * information required by peers to reach the device should be published 
- * during this function via the modex_send() interface. 
+ * and create a BTL module to represent each device. Any addressing
+ * information required by peers to reach the device should be published
+ * during this function via the modex_send() interface.
  *
  */
 
 typedef struct mca_btl_base_module_t** (*mca_btl_base_component_init_fn_t)(
-    int *num_btls, 
+    int *num_btls,
     bool enable_progress_threads,
     bool enable_mpi_threads
 );
@@ -492,8 +492,8 @@ typedef struct mca_btl_base_module_t** (*mca_btl_base_component_init_fn_t)(
  * MCA->BTL Called to progress outstanding requests for
  * non-threaded polling environments.
  *
- * @return           Count of "completions", a metric of 
- *                   how many items where completed in the call 
+ * @return           Count of "completions", a metric of
+ *                   how many items where completed in the call
  *                   to progress.
  */
 
@@ -502,22 +502,22 @@ typedef int (*mca_btl_base_component_progress_fn_t)(void);
 
 /**
  * Callback function that is called asynchronously on receipt
- * of data by the transport layer. 
- * Note that the the mca_btl_base_descriptor_t is only valid within the 
- * completion function, this implies that all data payload in the 
- * mca_btl_base_descriptor_t must be copied out within this callback or 
+ * of data by the transport layer.
+ * Note that the the mca_btl_base_descriptor_t is only valid within the
+ * completion function, this implies that all data payload in the
+ * mca_btl_base_descriptor_t must be copied out within this callback or
  * forfeited back to the BTL.
  * Note also that descriptor segments (des_segments) must be base
  * segments for all callbacks.
- * 
+ *
  * @param[IN] btl        BTL module
- * @param[IN] tag        The active message receive callback tag value 
- * @param[IN] descriptor The BTL descriptor (contains the receive payload) 
+ * @param[IN] tag        The active message receive callback tag value
+ * @param[IN] descriptor The BTL descriptor (contains the receive payload)
  * @param[IN] cbdata     Opaque callback data
  */
 
 typedef void (*mca_btl_base_module_recv_cb_fn_t)(
-    struct mca_btl_base_module_t* btl, 
+    struct mca_btl_base_module_t* btl,
     mca_btl_base_tag_t tag,
     mca_btl_base_descriptor_t* descriptor,
     void* cbdata
@@ -559,24 +559,24 @@ typedef struct mca_btl_base_component_3_0_0_t mca_btl_base_component_2_0_0_t;
  */
 
 /**
- * MCA->BTL Clean up any resources held by BTL module 
+ * MCA->BTL Clean up any resources held by BTL module
  * before the module is unloaded.
- *  
+ *
  * @param btl (IN)   BTL module.
  * @return           OPAL_SUCCESS or error status on failure.
  *
- * Prior to unloading a BTL module, the MCA framework will call 
- * the BTL finalize method of the module. Any resources held by 
+ * Prior to unloading a BTL module, the MCA framework will call
+ * the BTL finalize method of the module. Any resources held by
  * the BTL should be released and if required the memory corresponding
  * to the BTL module freed.
- * 
+ *
  */
 typedef int (*mca_btl_base_module_finalize_fn_t)(
     struct mca_btl_base_module_t* btl
 );
-                                                                                                         
+
 /**
- * BML->BTL notification of change in the process list. 
+ * BML->BTL notification of change in the process list.
  *
  * @param btl (IN)            BTL module
  * @param nprocs (IN)         Number of processes
@@ -585,24 +585,24 @@ typedef int (*mca_btl_base_module_finalize_fn_t)(
  * @param reachable (OUT)     Bitmask indicating set of peer processes that are reachable by this BTL.
  * @return                    OPAL_SUCCESS or error status on failure.
  *
- * The mca_btl_base_module_add_procs_fn_t() is called by the BML to 
+ * The mca_btl_base_module_add_procs_fn_t() is called by the BML to
  * determine the set of BTLs that should be used to reach each process.
  * Any addressing information exported by the peer via the modex_send()
- * function should be available during this call via the corresponding 
- * modex_recv() function. The BTL may utilize this information to 
- * determine reachability of each peer process. 
+ * function should be available during this call via the corresponding
+ * modex_recv() function. The BTL may utilize this information to
+ * determine reachability of each peer process.
  *
- * For each process that is reachable by the BTL, the bit corresponding to the index 
- * into the proc array (nprocs) should be set in the reachable bitmask. The BTL 
+ * For each process that is reachable by the BTL, the bit corresponding to the index
+ * into the proc array (nprocs) should be set in the reachable bitmask. The BTL
  * will return an array of pointers to a data structure defined
  * by the BTL that is then returned to the BTL on subsequent calls to the BTL data
- * transfer functions (e.g btl_send). This may be used by the BTL to cache any addressing 
+ * transfer functions (e.g btl_send). This may be used by the BTL to cache any addressing
  * or connection information (e.g. TCP socket, IB queue pair).
  */
 typedef int (*mca_btl_base_module_add_procs_fn_t)(
-    struct mca_btl_base_module_t* btl, 
+    struct mca_btl_base_module_t* btl,
     size_t nprocs,
-    struct opal_proc_t** procs, 
+    struct opal_proc_t** procs,
     struct mca_btl_base_endpoint_t** endpoints,
     struct opal_bitmap_t* reachable
 );
@@ -621,9 +621,9 @@ typedef int (*mca_btl_base_module_add_procs_fn_t)(
  * resources associated with the peer.
  */
 typedef int (*mca_btl_base_module_del_procs_fn_t)(
-    struct mca_btl_base_module_t* btl, 
+    struct mca_btl_base_module_t* btl,
     size_t nprocs,
-    struct opal_proc_t** procs, 
+    struct opal_proc_t** procs,
     struct mca_btl_base_endpoint_t** peer
 );
 
@@ -632,17 +632,17 @@ typedef int (*mca_btl_base_module_del_procs_fn_t)(
  * of a fragment.
  *
  * @param[IN] btl      BTL module
- * @param[IN] tag      tag value of this callback 
+ * @param[IN] tag      tag value of this callback
  *                     (specified on subsequent send operations)
  * @param[IN] cbfunc   The callback function
- * @param[IN] cbdata   Opaque callback data 
- * 
+ * @param[IN] cbdata   Opaque callback data
+ *
  * @return OPAL_SUCCESS The callback was registered successfully
  * @return OPAL_ERROR   The callback was NOT registered successfully
  *
  */
 typedef int (*mca_btl_base_module_register_fn_t)(
-    struct mca_btl_base_module_t* btl, 
+    struct mca_btl_base_module_t* btl,
     mca_btl_base_tag_t tag,
     mca_btl_base_module_recv_cb_fn_t cbfunc,
     void* cbdata
@@ -651,10 +651,10 @@ typedef int (*mca_btl_base_module_register_fn_t)(
 
 /**
  * Callback function that is called asynchronously on receipt
- * of an error from the transport layer 
+ * of an error from the transport layer
  *
  * @param[IN] btl     BTL module
- * @param[IN] flags   type of error 
+ * @param[IN] flags   type of error
  * @param[IN] errproc process that had an error
  * @param[IN] btlinfo descriptive string from the BTL
  */
@@ -679,21 +679,21 @@ typedef void (*mca_btl_base_module_error_cb_fn_t)(
  *
  */
 typedef int (*mca_btl_base_module_register_error_fn_t)(
-    struct mca_btl_base_module_t* btl, 
+    struct mca_btl_base_module_t* btl,
     mca_btl_base_module_error_cb_fn_t cbfunc
 );
 
 
 /**
- * Allocate a descriptor with a segment of the requested size. 
+ * Allocate a descriptor with a segment of the requested size.
  * Note that the BTL layer may choose to return a smaller size
  * if it cannot support the request. The order tag value ensures that
- * operations on the descriptor that is allocated will be 
- * ordered w.r.t. a previous operation on a particular descriptor. 
- * Ordering is only guaranteed if the previous descriptor had its 
- * local completion callback function called and the order tag of 
+ * operations on the descriptor that is allocated will be
+ * ordered w.r.t. a previous operation on a particular descriptor.
+ * Ordering is only guaranteed if the previous descriptor had its
+ * local completion callback function called and the order tag of
  * that descriptor is only valid upon the local completion callback function.
- * 
+ *
  *
  * @param btl (IN)      BTL module
  * @param size (IN)     Request segment size.
@@ -710,9 +710,9 @@ typedef mca_btl_base_descriptor_t* (*mca_btl_base_module_alloc_fn_t)(
 
 /**
  * Return a descriptor allocated from this BTL via alloc/prepare.
- * A descriptor can only be deallocated after its local completion 
+ * A descriptor can only be deallocated after its local completion
  * callback function has called for all send/put/get operations.
- * 
+ *
  * @param btl (IN)      BTL module
  * @param segment (IN)  Descriptor allocated from the BTL
  */
@@ -728,11 +728,11 @@ typedef int (*mca_btl_base_module_free_fn_t)(
  * user buffer. Otherwise, this routine is responsible for allocating buffer
  * space and packing if required.
  *
- * The order tag value ensures that operations on the 
+ * The order tag value ensures that operations on the
  * descriptor that is prepared will be ordered w.r.t. a previous
- * operation on a particular descriptor. Ordering is only guaranteed if 
- * the previous descriptor had its local completion callback function 
- * called and the order tag of that descriptor is only valid upon the local 
+ * operation on a particular descriptor. Ordering is only guaranteed if
+ * the previous descriptor had its local completion callback function
+ * called and the order tag of that descriptor is only valid upon the local
  * completion callback function.
  *
  * @param btl (IN)          BTL module
@@ -803,19 +803,19 @@ typedef int (*mca_btl_base_module_deregister_mem_fn_t)(
 /**
  * Initiate an asynchronous send.
  * Completion Semantics: the descriptor has been queued for a send operation
- *                       the BTL now controls the descriptor until local 
+ *                       the BTL now controls the descriptor until local
  *                       completion callback is made on the descriptor
- *                       
+ *
  * All BTLs allow multiple concurrent asynchronous send operations on a descriptor
  *
  * @param btl (IN)         BTL module
  * @param endpoint (IN)    BTL addressing information
  * @param descriptor (IN)  Description of the data to be transfered
  * @param tag (IN)         The tag value used to notify the peer.
- * 
- * @retval OPAL_SUCCESS    The descriptor was successfully queued for a send 
- * @retval OPAL_ERROR      The descriptor was NOT successfully queued for a send 
- * @retval OPAL_ERR_UNREACH The endpoint is not reachable 
+ *
+ * @retval OPAL_SUCCESS    The descriptor was successfully queued for a send
+ * @retval OPAL_ERROR      The descriptor was NOT successfully queued for a send
+ * @retval OPAL_ERR_UNREACH The endpoint is not reachable
  */
 typedef int (*mca_btl_base_module_send_fn_t)(
     struct mca_btl_base_module_t* btl,
@@ -825,12 +825,12 @@ typedef int (*mca_btl_base_module_send_fn_t)(
 );
 
 /**
- * Initiate an immediate blocking send. 
- * Completion Semantics: the BTL will make a best effort 
- *  to send the header and "size" bytes from the datatype using the convertor. 
- *  The header is guaranteed to be delivered entirely in the first segment. 
- *  Should the BTL be unable to deliver the data due to resource constraints 
- *  the BTL will return a descriptor (via the OUT param) 
+ * Initiate an immediate blocking send.
+ * Completion Semantics: the BTL will make a best effort
+ *  to send the header and "size" bytes from the datatype using the convertor.
+ *  The header is guaranteed to be delivered entirely in the first segment.
+ *  Should the BTL be unable to deliver the data due to resource constraints
+ *  the BTL will return a descriptor (via the OUT param)
  *  of size "payload_size + header_size".
  *
  * @param btl (IN)             BTL module
@@ -845,11 +845,11 @@ typedef int (*mca_btl_base_module_send_fn_t)(
  * @param descriptor (OUT)     The descriptor to be returned unable to be sent immediately
  *                             (may be NULL).
  *
- * @retval OPAL_SUCCESS           The send was successfully queued  
- * @retval OPAL_ERROR             The send failed 
- * @retval OPAL_ERR_UNREACH       The endpoint is not reachable 
- * @retval OPAL_ERR_RESOURCE_BUSY The BTL is busy a descriptor will be returned 
- *                                (via the OUT param) if descriptors are available 
+ * @retval OPAL_SUCCESS           The send was successfully queued
+ * @retval OPAL_ERROR             The send failed
+ * @retval OPAL_ERR_UNREACH       The endpoint is not reachable
+ * @retval OPAL_ERR_RESOURCE_BUSY The BTL is busy a descriptor will be returned
+ *                                (via the OUT param) if descriptors are available
  */
 
 typedef int (*mca_btl_base_module_sendi_fn_t)(
@@ -866,7 +866,7 @@ typedef int (*mca_btl_base_module_sendi_fn_t)(
  );
 
 /**
- * Initiate an asynchronous put. 
+ * Initiate an asynchronous put.
  * Completion Semantics: if this function returns a 1 then the operation
  *                       is complete. a return of OPAL_SUCCESS indicates
  *                       the put operation has been queued with the
@@ -1132,7 +1132,7 @@ struct mca_btl_base_module_t {
     mca_btl_base_module_sendi_fn_t          btl_sendi;
     mca_btl_base_module_put_fn_t            btl_put;
     mca_btl_base_module_get_fn_t            btl_get;
-    mca_btl_base_module_dump_fn_t           btl_dump; 
+    mca_btl_base_module_dump_fn_t           btl_dump;
 
     /* atomic operations */
     mca_btl_base_module_atomic_op64_fn_t    btl_atomic_op;
@@ -1143,9 +1143,9 @@ struct mca_btl_base_module_t {
     mca_btl_base_module_register_mem_fn_t   btl_register_mem;   /**< memory registration function (NULL if not needed) */
     mca_btl_base_module_deregister_mem_fn_t btl_deregister_mem; /**< memory deregistration function (NULL if not needed) */
 
-    /** the mpool associated with this btl (optional) */ 
-    mca_mpool_base_module_t*             btl_mpool; 
-    /** register a default error handler */ 
+    /** the mpool associated with this btl (optional) */
+    mca_mpool_base_module_t*             btl_mpool;
+    /** register a default error handler */
     mca_btl_base_module_register_error_fn_t btl_register_error;
     /** fault tolerant even notification */
     mca_btl_base_module_ft_event_fn_t btl_ft_event;

--- a/opal/mca/btl/btl.h
+++ b/opal/mca/btl/btl.h
@@ -14,6 +14,7 @@
  *                         reserved. 
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2012-2013 NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -770,6 +771,11 @@ typedef struct mca_btl_base_descriptor_t* (*mca_btl_base_module_prepare_fn_t)(
  * the btl_put, btl_get, btl_atomic_cas, btl_atomic_op, and btl_atomic_fop
  * functions. Care should be taken to not hold an excessive number of registrations
  * as they may use limited system/NIC resources.
+ *
+ * Ownership of the memory pointed to by the returned (struct
+ * mca_btl_base_registration_handle_t*) is passed to the caller.  The
+ * BTL module cannot free or reuse the handle until it is returned via
+ * the mca_btl_base_module_deregister_mem_fn_t function.
  */
 typedef struct mca_btl_base_registration_handle_t *(*mca_btl_base_module_register_mem_fn_t)(
     struct mca_btl_base_module_t* btl, struct mca_btl_base_endpoint_t *endpoint, void *base,
@@ -785,6 +791,11 @@ typedef struct mca_btl_base_registration_handle_t *(*mca_btl_base_module_registe
  * should be taken to not perform any RDMA or atomic operation on this memory region
  * after it is deregistered. It is erroneous to specify a memory handle associated with
  * a remote node.
+ *
+ * The handle passed in will be a value previously returned by the
+ * mca_btl_base_module_register_mem_fn_t function.  Ownership of the
+ * memory pointed to by handle passes to the BTL module; this function
+ * is now is allowed to free the memory, return it to a freelist, etc.
  */
 typedef int (*mca_btl_base_module_deregister_mem_fn_t)(
     struct mca_btl_base_module_t* btl, struct mca_btl_base_registration_handle_t *handle);

--- a/opal/mca/btl/usnic/btl_usnic_ack.c
+++ b/opal/mca/btl/usnic/btl_usnic_ack.c
@@ -148,12 +148,20 @@ opal_btl_usnic_handle_ack(
          * lines below.
          */
         if (frag->sf_ack_bytes_left == bytes_acked) {
+#if BTL_VERSION == 30
             if (frag->sf_base.uf_remote_seg[0].seg_addr.pval != NULL) {
                 OPAL_BTL_USNIC_DO_PUT_FRAG_CB(module, frag, "put completion");
             } else if (frag->sf_base.uf_base.des_flags &
                        MCA_BTL_DES_SEND_ALWAYS_CALLBACK) {
                 OPAL_BTL_USNIC_DO_SEND_FRAG_CB(module, frag, "send completion");
             }
+#else
+            if ((frag->sf_base.uf_remote_seg[0].seg_addr.pval != NULL) ||
+                (frag->sf_base.uf_base.des_flags &
+                 MCA_BTL_DES_SEND_ALWAYS_CALLBACK)) {
+                OPAL_BTL_USNIC_DO_SEND_FRAG_CB(module, frag, "send completion");
+            }
+#endif
         }
 
         /* free this segment */

--- a/opal/mca/btl/usnic/btl_usnic_ack.c
+++ b/opal/mca/btl/usnic/btl_usnic_ack.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -147,11 +147,13 @@ opal_btl_usnic_handle_ack(
          * fragment really needs to be freed, we'll take care of it in a few
          * lines below.
          */
-        if (frag->sf_ack_bytes_left == bytes_acked &&
-            ((frag->sf_base.uf_remote_seg[0].seg_addr.pval != NULL) ||
-             (frag->sf_base.uf_base.des_flags &
-              MCA_BTL_DES_SEND_ALWAYS_CALLBACK))) {
-            OPAL_BTL_USNIC_DO_SEND_FRAG_CB(module, frag, "send completion");
+        if (frag->sf_ack_bytes_left == bytes_acked) {
+            if (frag->sf_base.uf_remote_seg[0].seg_addr.pval != NULL) {
+                OPAL_BTL_USNIC_DO_PUT_FRAG_CB(module, frag, "put completion");
+            } else if (frag->sf_base.uf_base.des_flags &
+                       MCA_BTL_DES_SEND_ALWAYS_CALLBACK) {
+                OPAL_BTL_USNIC_DO_SEND_FRAG_CB(module, frag, "send completion");
+            }
         }
 
         /* free this segment */

--- a/opal/mca/btl/usnic/btl_usnic_ack.h
+++ b/opal/mca/btl/usnic/btl_usnic_ack.h
@@ -17,6 +17,7 @@
 #include "btl_usnic.h"
 #include "btl_usnic_frag.h"
 #include "btl_usnic_endpoint.h"
+#include "btl_usnic_compat.h"
 
 /* Invoke the descriptor callback for a (non-PUT) send frag, updating
  * stats and clearing the _CALLBACK flag in the process. */
@@ -34,6 +35,7 @@
         ++((module)->stats.pml_send_callbacks);                               \
     } while (0)
 
+#if BTL_VERSION == 30
 /* Invoke the descriptor callback for a send frag that was a PUT,
  * updating stats and clearing the _CALLBACK flag in the process. */
 #define OPAL_BTL_USNIC_DO_PUT_FRAG_CB(module, send_frag, comment)             \
@@ -53,6 +55,7 @@
              OPAL_SUCCESS);                                             \
         ++((module)->stats.pml_send_callbacks);                         \
     } while (0)
+#endif
 
 /*
  * Reap an ACK send that is complete

--- a/opal/mca/btl/usnic/btl_usnic_ack.h
+++ b/opal/mca/btl/usnic/btl_usnic_ack.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -18,11 +18,11 @@
 #include "btl_usnic_frag.h"
 #include "btl_usnic_endpoint.h"
 
-/* Invoke the descriptor callback for the frag, updating stats and clearing the
- * _CALLBACK flag in the process. */
+/* Invoke the descriptor callback for a (non-PUT) send frag, updating
+ * stats and clearing the _CALLBACK flag in the process. */
 #define OPAL_BTL_USNIC_DO_SEND_FRAG_CB(module, send_frag, comment)            \
     do {                                                                      \
-        MSGDEBUG1_OUT("%s:%d: %s send callback for module=%p frag=%p\n",      \
+        MSGDEBUG1_OUT("%s:%d: %s SEND callback for module=%p frag=%p\n",      \
                       __func__, __LINE__,                                     \
                       (comment), (void *)(module), (void *)(send_frag));      \
         (send_frag)->sf_base.uf_base.des_cbfunc(                              \
@@ -32,6 +32,26 @@
             OPAL_SUCCESS);                                                    \
         frag->sf_base.uf_base.des_flags &= ~MCA_BTL_DES_SEND_ALWAYS_CALLBACK; \
         ++((module)->stats.pml_send_callbacks);                               \
+    } while (0)
+
+/* Invoke the descriptor callback for a send frag that was a PUT,
+ * updating stats and clearing the _CALLBACK flag in the process. */
+#define OPAL_BTL_USNIC_DO_PUT_FRAG_CB(module, send_frag, comment)             \
+    do {                                                                      \
+        MSGDEBUG1_OUT("%s:%d: %s PUT callback for module=%p frag=%p\n",       \
+                      __func__, __LINE__,                                     \
+                      (comment), (void *)(module), (void *)(send_frag));      \
+        mca_btl_base_rdma_completion_fn_t func =                        \
+            (mca_btl_base_rdma_completion_fn_t)                         \
+            (send_frag)->sf_base.uf_base.des_cbfunc;                    \
+        func(&(module)->super,                                          \
+             (send_frag)->sf_endpoint,                                  \
+             (send_frag)->sf_base.uf_local_seg[0].seg_addr.pval,        \
+             NULL,                                                      \
+             (send_frag)->sf_base.uf_base.des_context,                  \
+             (send_frag)->sf_base.uf_base.des_cbdata,                   \
+             OPAL_SUCCESS);                                             \
+        ++((module)->stats.pml_send_callbacks);                         \
     } while (0)
 
 /*

--- a/opal/mca/btl/usnic/btl_usnic_compat.c
+++ b/opal/mca/btl/usnic/btl_usnic_compat.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -9,15 +9,20 @@
 
 #if BTL_IN_OPAL
 #include "opal_config.h"
+#include "opal/mca/btl/btl.h"
 #else
 #include "ompi_config.h"
+#include "ompi/mca/btl/btl.h"
 #endif
 
 #include "opal/mca/mca.h"
 #include "opal_stdint.h"
 
 #include "btl_usnic_compat.h"
+#include "btl_usnic_frag.h"
 #include "btl_usnic_endpoint.h"
+#include "btl_usnic_connectivity.h"
+#include "btl_usnic_send.h"
 
 /************************************************************************/
 
@@ -114,4 +119,599 @@ const char *usnic_compat_proc_name_print(opal_process_name_t *pname)
     return OMPI_NAME_PRINT(pname);
 }
 
+#endif /* OMPI version */
+
+/************************************************************************/
+
+/* BTL 2.0 and 3.0 compatibilty functions */
+
+/*----------------------------------------------------------------------*/
+
+/* The following functions are common between BTL 2.0 and 3.0 */
+
+/* Responsible for sending "small" frags (reserve + *size <= max_frag_payload)
+ * in the same manner as btl_prepare_src.  Must return a smaller amount than
+ * requested if the given convertor cannot process the entire (*size).
+ */
+static inline opal_btl_usnic_send_frag_t *
+prepare_src_small(
+    struct opal_btl_usnic_module_t* module,
+    struct mca_btl_base_endpoint_t* endpoint,
+    struct opal_convertor_t* convertor,
+    uint8_t order,
+    size_t reserve,
+    size_t* size,
+    uint32_t flags)
+{
+    opal_btl_usnic_send_frag_t *frag;
+    opal_btl_usnic_small_send_frag_t *sfrag;
+    size_t payload_len;
+
+    payload_len = *size + reserve;
+    assert(payload_len <= module->max_frag_payload); /* precondition */
+
+    sfrag = opal_btl_usnic_small_send_frag_alloc(module);
+    if (OPAL_UNLIKELY(NULL == sfrag)) {
+        return NULL;
+    }
+    frag = &sfrag->ssf_base;
+
+    /* In the case of a convertor, we will copy the data in now, since that is
+     * the cheapest way to discover how much we can actually send (since we know
+     * we will pack it anyway later).  The alternative is to do all of the
+     * following:
+     * 1) clone_with_position(convertor) and see where the new position ends up
+     *    actually being (see opal_btl_usnic_convertor_pack_peek).  Otherwise we
+     *    aren't fulfilling our contract w.r.t. (*size).
+     * 2) Add a bunch of branches checking for different cases, both here and in
+     *    progress_sends
+     * 3) If we choose to defer the packing, we must clone the convertor because
+     *    the PML owns it and might reuse it for another prepare_src call.
+     *
+     * Two convertor clones is likely to be at least as slow as just copying the
+     * data and might consume a similar amount of memory.  Plus we still have to
+     * pack it later to send it.
+     *
+     * The reason we do not copy non-convertor buffer at this point is because
+     * we might still use INLINE for the send, and in that case we do not want
+     * to copy the data at all.
+     */
+    if (OPAL_UNLIKELY(opal_convertor_need_buffers(convertor))) {
+        /* put user data just after end of 1st seg (upper layer header) */
+        assert(payload_len <= module->max_frag_payload);
+        usnic_convertor_pack_simple(
+                convertor,
+                (IOVBASE_TYPE*)(intptr_t)(frag->sf_base.uf_local_seg[0].seg_addr.lval + reserve),
+                *size,
+                size);
+        payload_len = reserve + *size;
+        frag->sf_base.uf_base.USNIC_SEND_LOCAL_COUNT = 1;
+        /* PML will copy header into beginning of segment */
+        frag->sf_base.uf_local_seg[0].seg_len = payload_len;
+    } else {
+        opal_convertor_get_current_pointer(convertor,
+                                           &sfrag->ssf_base.sf_base.uf_local_seg[1].seg_addr.pval);
+        frag->sf_base.uf_base.USNIC_SEND_LOCAL_COUNT = 2;
+        frag->sf_base.uf_local_seg[0].seg_len = reserve;
+        frag->sf_base.uf_local_seg[1].seg_len = *size;
+    }
+
+    frag->sf_base.uf_base.des_flags = flags;
+    frag->sf_endpoint = endpoint;
+
+    return frag;
+}
+
+static void *
+pack_chunk_seg_chain_with_reserve(
+    struct opal_btl_usnic_module_t* module,
+    opal_btl_usnic_large_send_frag_t *lfrag,
+    size_t reserve_len,
+    opal_convertor_t *convertor,
+    size_t max_convertor_bytes,
+    size_t *convertor_bytes_packed)
+{
+    opal_btl_usnic_chunk_segment_t *seg;
+    void *ret_ptr = NULL;
+    int n_segs;
+    uint8_t *copyptr;
+    size_t copylen;
+    size_t seg_space;
+    size_t max_data;
+    bool first_pass;
+
+    assert(NULL != lfrag);
+    assert(NULL != convertor_bytes_packed);
+
+    n_segs = 0;
+    *convertor_bytes_packed = 0;
+
+    first_pass = true;
+    while (*convertor_bytes_packed < max_convertor_bytes ||
+           first_pass) {
+        seg = opal_btl_usnic_chunk_segment_alloc(module);
+        if (OPAL_UNLIKELY(NULL == seg)) {
+            BTL_ERROR(("chunk segment allocation error"));
+            abort(); /* XXX */
+        }
+        ++n_segs;
+
+        seg_space = module->max_chunk_payload;
+        copyptr = seg->ss_base.us_payload.raw;
+
+        if (first_pass) {
+            /* logic could accommodate >max, but currently doesn't */
+            assert(reserve_len <= module->max_chunk_payload);
+            ret_ptr = copyptr;
+            seg_space -= reserve_len;
+            copyptr += reserve_len;
+        }
+
+        /* now pack any convertor data */
+        if (*convertor_bytes_packed < max_convertor_bytes && seg_space > 0) {
+            copylen = max_convertor_bytes - *convertor_bytes_packed;
+            if (copylen > seg_space) {
+                copylen = seg_space;
+            }
+            usnic_convertor_pack_simple(convertor, copyptr, copylen, &max_data);
+            seg_space -= max_data;
+            *convertor_bytes_packed += max_data;
+
+            /* If unable to pack any of the remaining bytes, release the
+            * most recently allocated segment and finish processing.
+            */
+            if (seg_space == module->max_chunk_payload) {
+                assert(max_data == 0); /* only way this can happen */
+                opal_btl_usnic_chunk_segment_return(module, seg);
+                break;
+            }
+        }
+
+        /* bozo checks */
+        assert(seg_space >= 0);
+        assert(seg_space < module->max_chunk_payload);
+
+        /* append segment of data to chain to send */
+        seg->ss_parent_frag = &lfrag->lsf_base;
+        seg->ss_len = module->max_chunk_payload - seg_space;
+        opal_list_append(&lfrag->lsf_seg_chain, &seg->ss_base.us_list.super);
+
+#if MSGDEBUG1
+        opal_output(0, "%s: appending seg=%p, frag=%p, payload=%zd\n",
+                    __func__, (void *)seg, (void *)lfrag,
+                    (module->max_chunk_payload - seg_space));
 #endif
+
+        first_pass = false;
+    }
+
+    return ret_ptr;
+}
+
+/* Responsible for handling "large" frags (reserve + *size > max_frag_payload)
+ * in the same manner as btl_prepare_src.  Must return a smaller amount than
+ * requested if the given convertor cannot process the entire (*size).
+ */
+static opal_btl_usnic_send_frag_t *
+prepare_src_large(
+    struct opal_btl_usnic_module_t* module,
+    struct mca_btl_base_endpoint_t* endpoint,
+    struct opal_convertor_t* convertor,
+    uint8_t order,
+    size_t reserve,
+    size_t* size,
+    uint32_t flags)
+{
+    opal_btl_usnic_send_frag_t *frag;
+    opal_btl_usnic_large_send_frag_t *lfrag;
+    int rc;
+
+    /* Get holder for the msg */
+    lfrag = opal_btl_usnic_large_send_frag_alloc(module);
+    if (OPAL_UNLIKELY(NULL == lfrag)) {
+        return NULL;
+    }
+    frag = &lfrag->lsf_base;
+
+    /* The header location goes in SG[0], payload in SG[1].  If we are using a
+     * convertor then SG[1].seg_len is accurate but seg_addr is NULL. */
+    frag->sf_base.uf_base.USNIC_SEND_LOCAL_COUNT = 2;
+
+    /* stash header location, PML will write here */
+    frag->sf_base.uf_local_seg[0].seg_addr.pval = &lfrag->lsf_ompi_header;
+    frag->sf_base.uf_local_seg[0].seg_len = reserve;
+    /* make sure upper header small enough */
+    assert(reserve <= sizeof(lfrag->lsf_ompi_header));
+
+    if (OPAL_UNLIKELY(opal_convertor_need_buffers(convertor))) {
+        /* threshold == -1 means always pack eagerly */
+        if (mca_btl_usnic_component.pack_lazy_threshold >= 0 &&
+            *size >= (size_t)mca_btl_usnic_component.pack_lazy_threshold) {
+            MSGDEBUG1_OUT("packing frag %p on the fly", (void *)frag);
+            lfrag->lsf_pack_on_the_fly = true;
+
+            /* tell the PML we will absorb as much as possible while still
+             * respecting indivisible element boundaries in the convertor */
+            *size = opal_btl_usnic_convertor_pack_peek(convertor, *size);
+
+            /* Clone the convertor b/c we (the BTL) don't own it and the PML
+             * might mutate it after we return from this function. */
+            rc = opal_convertor_clone(convertor, &frag->sf_convertor,
+                                      /*copy_stack=*/true);
+            if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
+                BTL_ERROR(("unexpected convertor clone error"));
+                abort(); /* XXX */
+            }
+        }
+        else {
+            /* pack everything in the convertor into a chain of segments now,
+             * leaving space for the PML header in the first segment */
+            lfrag->lsf_base.sf_base.uf_local_seg[0].seg_addr.pval =
+                pack_chunk_seg_chain_with_reserve(module, lfrag, reserve,
+                                                  convertor, *size, size);
+        }
+
+        /* We set SG[1] to {NULL,bytes_packed} so that various calculations
+         * by both PML and this BTL will be correct.  For example, the PML adds
+         * up the bytes in the descriptor segments to determine if an MPI-level
+         * request is complete or not. */
+        frag->sf_base.uf_local_seg[1].seg_addr.pval = NULL;
+        frag->sf_base.uf_local_seg[1].seg_len = *size;
+    } else {
+        /* convertor not needed, just save the payload pointer in SG[1] */
+        lfrag->lsf_pack_on_the_fly = true;
+        opal_convertor_get_current_pointer(convertor,
+                                           &frag->sf_base.uf_local_seg[1].seg_addr.pval);
+        frag->sf_base.uf_local_seg[1].seg_len = *size;
+    }
+
+    frag->sf_base.uf_base.des_flags = flags;
+    frag->sf_endpoint = endpoint;
+
+    return frag;
+}
+
+/*----------------------------------------------------------------------*/
+
+#if BTL_VERSION == 20
+
+/*
+ * BTL 2.0 version of module.btl_prepare_src.
+ *
+ * Note the "user" data the PML wishes to communicate and return a descriptor
+ * that can be used for send or put.  We create a frag (which is also a
+ * descriptor by virtue of its base class) and populate it with enough
+ * source information to complete a future send/put.
+ *
+ * We will create either a small send frag if < than an MTU, otherwise a large
+ * send frag.  The convertor will be saved for deferred packing if the user
+ * buffer is noncontiguous.  Otherwise it will be saved in one of the
+ * descriptor's SGEs.
+ *
+ * NOTE that the *only* reason this routine is allowed to return a size smaller
+ * than was requested is if the convertor cannot process the entire amount.
+ */
+mca_btl_base_descriptor_t*
+opal_btl_usnic_prepare_src(
+    struct mca_btl_base_module_t* base_module,
+    struct mca_btl_base_endpoint_t* endpoint,
+    struct mca_mpool_base_registration_t* registration,
+    struct opal_convertor_t* convertor,
+    uint8_t order,
+    size_t reserve,
+    size_t* size,
+    uint32_t flags)
+{
+    opal_btl_usnic_module_t *module = (opal_btl_usnic_module_t*) base_module;
+    opal_btl_usnic_send_frag_t *frag;
+    uint32_t payload_len;
+#if MSGDEBUG2
+    size_t osize = *size;
+#endif
+
+    /* Do we need to check the connectivity?  If enabled, we'll check
+       the connectivity at either first send to peer X or first ACK to
+       peer X. */
+    opal_btl_usnic_check_connectivity(module, endpoint);
+
+    /*
+     * if total payload len fits in one MTU use small send, else large
+     */
+    payload_len = *size + reserve;
+    if (payload_len <= module->max_frag_payload) {
+        frag = prepare_src_small(module, endpoint, convertor,
+                                 order, reserve, size, flags);
+    } else {
+        frag = prepare_src_large(module, endpoint, convertor,
+                                 order, reserve, size, flags);
+    }
+
+#if MSGDEBUG2
+    opal_output(0, "prep_src: %s %s frag %p, size=%d+%u (was %u), conv=%p\n",
+                module->fabric_info->fabric_attr->name,
+                (reserve + *size) <= module->max_frag_payload?"small":"large",
+                (void *)frag, (int)reserve, (unsigned)*size, (unsigned)osize,
+                (void *)convertor);
+#if MSGDEBUG1
+    {
+        unsigned i;
+        mca_btl_base_descriptor_t *desc = &frag->sf_base.uf_base;
+        for (i=0; i<desc->USNIC_SEND_LOCAL_COUNT; ++i) {
+            opal_output(0, "  %d: ptr:%p len:%d\n", i,
+                        (void *)desc->USNIC_SEND_LOCAL[i].seg_addr.pval,
+                        desc->USNIC_SEND_LOCAL[i].seg_len);
+        }
+    }
+#endif
+#endif
+
+    return &frag->sf_base.uf_base;
+}
+
+/*
+ * BTL 2.0 prepare_dst function (this function does not exist in BTL
+ * 3.0).
+ */
+mca_btl_base_descriptor_t*
+opal_btl_usnic_prepare_dst(
+    struct mca_btl_base_module_t* base_module,
+    struct mca_btl_base_endpoint_t* endpoint,
+    struct mca_mpool_base_registration_t* registration,
+    struct opal_convertor_t* convertor,
+    uint8_t order,
+    size_t reserve,
+    size_t* size,
+    uint32_t flags)
+{
+    opal_btl_usnic_put_dest_frag_t *pfrag;
+    opal_btl_usnic_module_t *module;
+    void *data_ptr;
+
+    module = (opal_btl_usnic_module_t *)base_module;
+
+    /* allocate a fragment for this */
+    pfrag = (opal_btl_usnic_put_dest_frag_t *)
+        opal_btl_usnic_put_dest_frag_alloc(module);
+    if (NULL == pfrag) {
+        return NULL;
+    }
+
+    /* find start of the data */
+    opal_convertor_get_current_pointer(convertor, (void **) &data_ptr);
+
+    /* make a seg entry pointing at data_ptr */
+    pfrag->uf_remote_seg[0].seg_addr.pval = data_ptr;
+    pfrag->uf_remote_seg[0].seg_len = *size;
+
+    pfrag->uf_base.order       = order;
+    pfrag->uf_base.des_flags   = flags;
+
+#if MSGDEBUG2
+    opal_output(0, "prep_dst size=%d, addr=%p, pfrag=%p\n", (int)*size,
+            data_ptr, (void *)pfrag);
+#endif
+
+    return &pfrag->uf_base;
+}
+
+
+/*
+ * BTL 2.0 version of module.btl_put.
+ *
+ * Emulate an RDMA put.  We'll send the remote address
+ * across to the other side so it will know where to put the data
+ */
+int opal_btl_usnic_put(
+    struct mca_btl_base_module_t *btl,
+    struct mca_btl_base_endpoint_t *endpoint,
+    struct mca_btl_base_descriptor_t *desc)
+{
+    int rc;
+    opal_btl_usnic_send_frag_t *frag;
+
+    frag = (opal_btl_usnic_send_frag_t *)desc;
+
+    opal_btl_usnic_compute_sf_size(frag);
+    frag->sf_ack_bytes_left = frag->sf_size;
+
+#if MSGDEBUG2
+    opal_output(0, "usnic_put, frag=%p, size=%d\n", (void *)frag,
+            (int)frag->sf_size);
+#if MSGDEBUG1
+    { unsigned i;
+        for (i=0; i<desc->USNIC_PUT_LOCAL_COUNT; ++i) {
+            opal_output(0, "  %d: ptr:%p len:%d%s\n", i,
+                    desc->USNIC_PUT_LOCAL[i].seg_addr.pval,
+                    desc->USNIC_PUT_LOCAL[i].seg_len,
+                    (i==0)?" (put local)":"");
+        }
+        for (i=0; i<desc->USNIC_PUT_REMOTE_COUNT; ++i) {
+            opal_output(0, "  %d: ptr:%p len:%d%s\n", i,
+                    desc->USNIC_PUT_REMOTE[i].seg_addr.pval,
+                    desc->USNIC_PUT_REMOTE[i].seg_len,
+                    (i==0)?" (put remote)":"");
+        }
+    }
+#endif
+#endif
+
+    /* RFXX copy out address - why does he not use our provided holder? */
+    /* JMS What does this mean? ^^ */
+    frag->sf_base.uf_remote_seg[0].seg_addr.pval =
+        desc->USNIC_PUT_REMOTE->seg_addr.pval;
+
+    rc = opal_btl_usnic_finish_put_or_send((opal_btl_usnic_module_t *)btl,
+                                           (opal_btl_usnic_endpoint_t *)endpoint,
+                                           frag,
+                                           /*tag=*/MCA_BTL_NO_ORDER);
+
+    return rc;
+}
+
+/*----------------------------------------------------------------------*/
+
+#elif BTL_VERSION == 30
+
+/*
+ * BTL 3.0 prepare_src function.
+ *
+ * This function is only used for sending PML fragments (not putting
+ * or getting fragments).
+ *
+ * Note the "user" data the PML wishes to communicate and return a
+ * descriptor.  We create a frag (which is also a descriptor by virtue
+ * of its base class) and populate it with enough source information
+ * to complete a future send.
+ *
+ * Recall that the usnic BTL's max_send_size is almost certainly
+ * larger than the MTU (by default, max_send_size is either 25K or
+ * 150K).  Therefore, the PML may give us a fragment up to
+ * max_send_size in this function.  Hence, we make the decision here
+ * as to whether it's a "small" fragment (i.e., size <= MTU, meaning
+ * that it fits in a single datagram) or a "large" fragment (i.e.,
+ * size > MTU, meaning that it must be chunked into multiple
+ * datagrams).
+ *
+ * The convertor will be saved for deferred packing if the user buffer
+ * is noncontiguous.  Otherwise, it will be saved in one of the
+ * descriptor's SGEs.
+ *
+ * NOTE that the *only* reason this routine is allowed to return a size smaller
+ * than was requested is if the convertor cannot process the entire amount.
+ */
+struct mca_btl_base_descriptor_t *
+opal_btl_usnic_prepare_src(struct mca_btl_base_module_t *base_module,
+                           struct mca_btl_base_endpoint_t *endpoint,
+                           struct opal_convertor_t *convertor,
+                           uint8_t order,
+                           size_t reserve,
+                           size_t *size,
+                           uint32_t flags)
+{
+    opal_btl_usnic_module_t *module = (opal_btl_usnic_module_t*) base_module;
+    opal_btl_usnic_send_frag_t *frag;
+    uint32_t payload_len;
+#if MSGDEBUG2
+    size_t osize = *size;
+#endif
+
+    /* Do we need to check the connectivity?  If enabled, we'll check
+       the connectivity at either first send to peer X or first ACK to
+       peer X. */
+    opal_btl_usnic_check_connectivity(module, endpoint);
+
+    /*
+     * if total payload len fits in one MTU use small send, else large
+     */
+    payload_len = *size + reserve;
+    if (payload_len <= module->max_frag_payload) {
+        frag = prepare_src_small(module, endpoint, convertor,
+                                 order, reserve, size, flags);
+    } else {
+        frag = prepare_src_large(module, endpoint, convertor,
+                                 order, reserve, size, flags);
+    }
+
+#if MSGDEBUG2
+    opal_output(0, "prep_src: %s %s frag %p, size=%d+%u (was %u), conv=%p\n",
+                module->fabric_info->fabric_attr->name,
+                (reserve + *size) <= module->max_frag_payload?"small":"large",
+                (void *)frag, (int)reserve, (unsigned)*size, (unsigned)osize,
+                (void *)convertor);
+#if MSGDEBUG1
+    {
+        unsigned i;
+        mca_btl_base_descriptor_t *desc = &frag->sf_base.uf_base;
+        for (i=0; i<desc->USNIC_SEND_LOCAL_COUNT; ++i) {
+            opal_output(0, "  %d: ptr:%p len:%d\n", i,
+                        (void *)desc->USNIC_SEND_LOCAL[i].seg_addr.pval,
+                        desc->USNIC_SEND_LOCAL[i].seg_len);
+        }
+    }
+#endif
+#endif
+
+    return &frag->sf_base.uf_base;
+}
+
+/*
+ * BTL 3.0 version of module.btl_put.
+ *
+ * Emulate an RDMA put.  We'll send the remote address across to the
+ * other side so it will know where to put the data.
+ *
+ * Note that this function is only ever called with contiguous
+ * buffers, so a convertor is not necessary.
+ */
+int
+opal_btl_usnic_put(struct mca_btl_base_module_t *base_module,
+                   struct mca_btl_base_endpoint_t *endpoint,
+                   void *local_address, uint64_t remote_address,
+                   struct mca_btl_base_registration_handle_t *local_handle,
+                   struct mca_btl_base_registration_handle_t *remote_handle,
+                   size_t size, int flags, int order,
+                   mca_btl_base_rdma_completion_fn_t cbfunc,
+                   void *cbcontext, void *cbdata)
+{
+    opal_btl_usnic_send_frag_t *sfrag;
+    opal_btl_usnic_module_t *module = (opal_btl_usnic_module_t*) base_module;
+
+    /* At least for the moment, continue to make a descriptor, like we
+       used to in BTL 2.0 */
+    if (size <= module->max_frag_payload) {
+        /* Small send fragment -- the whole thing fits in one MTU
+           (i.e., a single chunk) */
+        opal_btl_usnic_small_send_frag_t *ssfrag;
+        ssfrag = opal_btl_usnic_small_send_frag_alloc(module);
+        if (OPAL_UNLIKELY(NULL == ssfrag)) {
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+
+        sfrag = &ssfrag->ssf_base;
+    } else {
+        /* Large send fragment -- need more than one MTU (i.e.,
+           multiple chunks) */
+        opal_btl_usnic_large_send_frag_t *lsfrag;
+        lsfrag = opal_btl_usnic_large_send_frag_alloc(module);
+        if (OPAL_UNLIKELY(NULL == lsfrag)) {
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+
+        lsfrag->lsf_pack_on_the_fly = true;
+
+        sfrag = &lsfrag->lsf_base;
+    }
+
+    sfrag->sf_endpoint = endpoint;
+    sfrag->sf_size = size;
+    sfrag->sf_ack_bytes_left = size;
+
+    opal_btl_usnic_frag_t *frag;
+    frag = &sfrag->sf_base;
+    frag->uf_local_seg[0].seg_len = size;
+    frag->uf_local_seg[0].seg_addr.pval = local_address;
+    frag->uf_remote_seg[0].seg_len = size;
+    frag->uf_remote_seg[0].seg_addr.pval =
+        (void *)(uintptr_t) remote_address;
+
+    mca_btl_base_descriptor_t *desc;
+    desc = &frag->uf_base;
+    desc->des_segment_count = 1;
+    desc->des_segments = &frag->uf_local_seg[0];
+    /* This is really the wrong cbfunc type, but we'll cast it to
+       the Right type before we use it.  So it'll be ok. */
+    desc->des_cbfunc = (mca_btl_base_completion_fn_t) cbfunc;
+    desc->des_cbdata = cbdata;
+    desc->des_context = cbcontext;
+    desc->des_flags = flags;
+    desc->order = order;
+
+    int rc;
+    rc = opal_btl_usnic_finish_put_or_send(module,
+                                           (opal_btl_usnic_endpoint_t *)endpoint,
+                                           sfrag,
+                                           /*tag=*/MCA_BTL_NO_ORDER);
+    return rc;
+}
+
+#endif /* BTL_VERSION */

--- a/opal/mca/btl/usnic/btl_usnic_compat.h
+++ b/opal/mca/btl/usnic/btl_usnic_compat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,20 +40,20 @@
 #endif
 #  define USNIC_BTL_DEFAULT_VERSION(name) MCA_BTL_DEFAULT_VERSION(name)
 
-#  define USNIC_SEND_LOCAL        des_local
-#  define USNIC_SEND_LOCAL_COUNT  des_local_count
-#  define USNIC_SEND_REMOTE       des_remote
-#  define USNIC_SEND_REMOTE_COUNT des_remote_count
+#  define USNIC_SEND_LOCAL        des_segments
+#  define USNIC_SEND_LOCAL_COUNT  des_segment_count
+#  define USNIC_SEND_REMOTE       des_segments
+#  define USNIC_SEND_REMOTE_COUNT des_segment_count
 
-#  define USNIC_RECV_LOCAL        des_local
-#  define USNIC_RECV_LOCAL_COUNT  des_local_count
-#  define USNIC_RECV_REMOTE       des_remote
-#  define USNIC_RECV_REMOTE_COUNT des_remote_count
+#  define USNIC_RECV_LOCAL        des_segments
+#  define USNIC_RECV_LOCAL_COUNT  des_segment_count
+#  define USNIC_RECV_REMOTE       des_segments
+#  define USNIC_RECV_REMOTE_COUNT des_segment_count
 
-#  define USNIC_PUT_LOCAL         des_local
-#  define USNIC_PUT_LOCAL_COUNT   des_local_count
-#  define USNIC_PUT_REMOTE        des_remote
-#  define USNIC_PUT_REMOTE_COUNT  des_remote_count
+#  define USNIC_PUT_LOCAL         des_segments
+#  define USNIC_PUT_LOCAL_COUNT   des_segment_count
+#  define USNIC_PUT_REMOTE        des_segments
+#  define USNIC_PUT_REMOTE_COUNT  des_segments_count
 
 /*
  * Performance critical; needs to be inline

--- a/opal/mca/btl/usnic/btl_usnic_frag.c
+++ b/opal/mca/btl/usnic/btl_usnic_frag.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
- * Copyright (c) 2013-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -122,10 +122,17 @@ recv_seg_constructor(
         mca_btl_usnic_component.transport_header_len);
 
     /* initialize descriptor */
-    seg->rs_desc.USNIC_RECV_LOCAL = &seg->rs_segment;
-    seg->rs_desc.USNIC_RECV_LOCAL_COUNT = 1;
+    /* JMS Initializing RECV_REMOTE for receive frags is unnecessary
+       with BTL 3.0.  The only reason to keep this here would be for
+       compatibility with the BTL 2.0 usnic-v1.8 git branch (i.e.,
+       it's harmless to do this assignment first, before the
+       RECV_LOCAL assignments -- the compiler will likely compile out
+       this dead code, anyway). */
     seg->rs_desc.USNIC_RECV_REMOTE = NULL;
     seg->rs_desc.USNIC_RECV_REMOTE_COUNT = 0;
+
+    seg->rs_desc.USNIC_RECV_LOCAL = &seg->rs_segment;
+    seg->rs_desc.USNIC_RECV_LOCAL_COUNT = 1;
 
     /*
      * This pointer is only correct for incoming segments of type
@@ -144,12 +151,20 @@ send_frag_constructor(opal_btl_usnic_send_frag_t *frag)
 
     /* Fill in source descriptor */
     desc = &frag->sf_base.uf_base;
+
+    /* JMS Initializing SEND_REMOTE for receive frags is unnecessary
+       with BTL 3.0.  The only reason to keep this here would be for
+       compatibility with the BTL 2.0 usnic-v1.8 git branch (i.e.,
+       it's harmless to do this assignment first, before the
+       SEND_LOCAL assignments -- the compiler will likely compile out
+       this dead code, anyway). */
+    desc->USNIC_SEND_REMOTE = frag->sf_base.uf_remote_seg;
+    desc->USNIC_SEND_REMOTE_COUNT = 0;
+
     desc->USNIC_SEND_LOCAL = frag->sf_base.uf_local_seg;
     frag->sf_base.uf_local_seg[0].seg_len = 0;
     frag->sf_base.uf_local_seg[1].seg_len = 0;
     desc->USNIC_SEND_LOCAL_COUNT = 2;
-    desc->USNIC_SEND_REMOTE = frag->sf_base.uf_remote_seg;
-    desc->USNIC_SEND_REMOTE_COUNT = 0;
 
     desc->order = MCA_BTL_NO_ORDER;
     desc->des_flags = 0;

--- a/opal/mca/btl/usnic/btl_usnic_frag.h
+++ b/opal/mca/btl/usnic/btl_usnic_frag.h
@@ -587,6 +587,31 @@ opal_btl_usnic_ack_segment_return(
     OMPI_FREE_LIST_RETURN_MT(&(module->ack_segs), &(ack->ss_base.us_list));
 }
 
+/* Compute and set the proper value for sfrag->sf_size.  This must not be used
+ * during usnic_alloc, since the PML might change the segment size after
+ * usnic_alloc returns. */
+static inline void
+opal_btl_usnic_compute_sf_size(opal_btl_usnic_send_frag_t *sfrag)
+{
+    opal_btl_usnic_frag_t *frag;
+
+    frag = &sfrag->sf_base;
+
+    /* JMS This can be a put or a send, and the buffers are different... */
+#if 0
+    assert(frag->uf_base.USNIC_SEND_LOCAL_COUNT > 0);
+    assert(frag->uf_base.USNIC_SEND_LOCAL_COUNT <= 2);
+
+    /* belt and suspenders: second len should be zero if only one SGE */
+    assert(2 == frag->uf_base.USNIC_SEND_LOCAL_COUNT ||
+        0 == frag->uf_local_seg[1].seg_len);
+#endif
+
+    sfrag->sf_size = 0;
+    sfrag->sf_size += frag->uf_local_seg[0].seg_len;
+    sfrag->sf_size += frag->uf_local_seg[1].seg_len;
+}
+
 END_C_DECLS
 
 #endif

--- a/opal/mca/btl/usnic/btl_usnic_frag.h
+++ b/opal/mca/btl/usnic/btl_usnic_frag.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
- * Copyright (c) 2013-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -87,7 +87,7 @@ usnic_seg_type_str(opal_btl_usnic_seg_type_t t)
 
 typedef struct opal_btl_usnic_reg_t {
     mca_mpool_base_registration_t base;
-    struct fid_mr *mr;
+    struct fid_mr *ur_mr;
 } opal_btl_usnic_reg_t;
 
 

--- a/opal/mca/btl/usnic/btl_usnic_frag.h
+++ b/opal/mca/btl/usnic/btl_usnic_frag.h
@@ -145,7 +145,7 @@ typedef struct {
 
 /**
  * Descriptor for a common segment.  This is exactly one packet and may
- * be send or receive
+ * be sent or received.
  */
 typedef struct opal_btl_usnic_segment_t {
     ompi_free_list_item_t us_list;
@@ -221,7 +221,7 @@ typedef struct opal_btl_usnic_frag_t {
     /* fragment descriptor type */
     opal_btl_usnic_frag_type_t uf_type;
 
-    /* utility segments */
+    /* utility segments (just seg_addr/seg_len) */
     mca_btl_base_segment_t uf_local_seg[2];
     mca_btl_base_segment_t uf_remote_seg[1];
 

--- a/opal/mca/btl/usnic/btl_usnic_frag.h
+++ b/opal/mca/btl/usnic/btl_usnic_frag.h
@@ -85,6 +85,25 @@ usnic_seg_type_str(opal_btl_usnic_seg_type_t t)
 }
 
 
+/*
+ * usnic registration handle (passed over the network to peers as a
+ * cookie).
+ *
+ * Currently, this struct is meaningless (but it must be defined /
+ * exist) because we are emulating RDMA and do not have
+ * btl_register_mem and btl_deregister_mem functions (and we set
+ * module.btl_registration_handle_size to 0, not sizeof(struct
+ * mca_btl_base_registration_handle_t)).
+ */
+struct mca_btl_base_registration_handle_t {
+    /* Maybe we'll need fields like this */
+    uint32_t lkey;
+    uint32_t rkey;
+};
+
+/*
+ * usnic local registration
+ */
 typedef struct opal_btl_usnic_reg_t {
     mca_mpool_base_registration_t base;
     struct fid_mr *ur_mr;

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -68,30 +68,6 @@ static void finalize_one_channel(opal_btl_usnic_module_t *module,
                                  struct opal_btl_usnic_channel_t *channel);
 
 
-/* Compute and set the proper value for sfrag->sf_size.  This must not be used
- * during usnic_alloc, since the PML might change the segment size after
- * usnic_alloc returns. */
-static inline void compute_sf_size(opal_btl_usnic_send_frag_t *sfrag)
-{
-    opal_btl_usnic_frag_t *frag;
-
-    frag = &sfrag->sf_base;
-
-    /* JMS This can be a put or a send, and the buffers are different... */
-#if 0
-    assert(frag->uf_base.USNIC_SEND_LOCAL_COUNT > 0);
-    assert(frag->uf_base.USNIC_SEND_LOCAL_COUNT <= 2);
-
-    /* belt and suspenders: second len should be zero if only one SGE */
-    assert(2 == frag->uf_base.USNIC_SEND_LOCAL_COUNT ||
-        0 == frag->uf_local_seg[1].seg_len);
-#endif
-
-    sfrag->sf_size = 0;
-    sfrag->sf_size += frag->uf_local_seg[0].seg_len;
-    sfrag->sf_size += frag->uf_local_seg[1].seg_len;
-}
-
 /*
  * Loop over all procs sent to us in add_procs and see if we want to
  * add a proc/endpoint for them.
@@ -644,80 +620,6 @@ static int usnic_free(struct mca_btl_base_module_t* btl,
     return OPAL_SUCCESS;
 }
 
-/* Responsible for sending "small" frags (reserve + *size <= max_frag_payload)
- * in the same manner as btl_prepare_src.  Must return a smaller amount than
- * requested if the given convertor cannot process the entire (*size).
- */
-static inline
-opal_btl_usnic_send_frag_t *
-prepare_src_small(
-    struct opal_btl_usnic_module_t* module,
-    struct mca_btl_base_endpoint_t* endpoint,
-    struct opal_convertor_t* convertor,
-    uint8_t order,
-    size_t reserve,
-    size_t* size,
-    uint32_t flags)
-{
-    opal_btl_usnic_send_frag_t *frag;
-    opal_btl_usnic_small_send_frag_t *sfrag;
-    size_t payload_len;
-
-    payload_len = *size + reserve;
-    assert(payload_len <= module->max_frag_payload); /* precondition */
-
-    sfrag = opal_btl_usnic_small_send_frag_alloc(module);
-    if (OPAL_UNLIKELY(NULL == sfrag)) {
-        return NULL;
-    }
-    frag = &sfrag->ssf_base;
-
-    /* In the case of a convertor, we will copy the data in now, since that is
-     * the cheapest way to discover how much we can actually send (since we know
-     * we will pack it anyway later).  The alternative is to do all of the
-     * following:
-     * 1) clone_with_position(convertor) and see where the new position ends up
-     *    actually being (see opal_btl_usnic_convertor_pack_peek).  Otherwise we
-     *    aren't fulfilling our contract w.r.t. (*size).
-     * 2) Add a bunch of branches checking for different cases, both here and in
-     *    progress_sends
-     * 3) If we choose to defer the packing, we must clone the convertor because
-     *    the PML owns it and might reuse it for another prepare_src call.
-     *
-     * Two convertor clones is likely to be at least as slow as just copying the
-     * data and might consume a similar amount of memory.  Plus we still have to
-     * pack it later to send it.
-     *
-     * The reason we do not copy non-convertor buffer at this point is because
-     * we might still use INLINE for the send, and in that case we do not want
-     * to copy the data at all.
-     */
-    if (OPAL_UNLIKELY(opal_convertor_need_buffers(convertor))) {
-        /* put user data just after end of 1st seg (upper layer header) */
-        assert(payload_len <= module->max_frag_payload);
-        usnic_convertor_pack_simple(
-                convertor,
-                (IOVBASE_TYPE*)(intptr_t)(frag->sf_base.uf_local_seg[0].seg_addr.lval + reserve),
-                *size,
-                size);
-        payload_len = reserve + *size;
-        frag->sf_base.uf_base.USNIC_SEND_LOCAL_COUNT = 1;
-        /* PML will copy header into beginning of segment */
-        frag->sf_base.uf_local_seg[0].seg_len = payload_len;
-    } else {
-        opal_convertor_get_current_pointer(convertor,
-                                           &sfrag->ssf_base.sf_base.uf_local_seg[1].seg_addr.pval);
-        frag->sf_base.uf_base.USNIC_SEND_LOCAL_COUNT = 2;
-        frag->sf_base.uf_local_seg[0].seg_len = reserve;
-        frag->sf_base.uf_local_seg[1].seg_len = *size;
-    }
-
-    frag->sf_base.uf_base.des_flags = flags;
-    frag->sf_endpoint = endpoint;
-
-    return frag;
-}
-
 /* Packs data from the given large send frag into single new segment and
  * returns a pointer to it.  The packed data comes first from SG[0] (PML
  * header) and then second from either SG[1] (if seg_addr is non-NULL) or from
@@ -807,338 +709,6 @@ pack_chunk_seg_from_frag(
     seg->ss_len = module->max_chunk_payload - seg_space;
 
     return seg;
-}
-
-static
-void *
-pack_chunk_seg_chain_with_reserve(
-    struct opal_btl_usnic_module_t* module,
-    opal_btl_usnic_large_send_frag_t *lfrag,
-    size_t reserve_len,
-    opal_convertor_t *convertor,
-    size_t max_convertor_bytes,
-    size_t *convertor_bytes_packed)
-{
-    opal_btl_usnic_chunk_segment_t *seg;
-    void *ret_ptr = NULL;
-    int n_segs;
-    uint8_t *copyptr;
-    size_t copylen;
-    size_t seg_space;
-    size_t max_data;
-    bool first_pass;
-
-    assert(NULL != lfrag);
-    assert(NULL != convertor_bytes_packed);
-
-    n_segs = 0;
-    *convertor_bytes_packed = 0;
-
-    first_pass = true;
-    while (*convertor_bytes_packed < max_convertor_bytes ||
-           first_pass) {
-        seg = opal_btl_usnic_chunk_segment_alloc(module);
-        if (OPAL_UNLIKELY(NULL == seg)) {
-            BTL_ERROR(("chunk segment allocation error"));
-            abort(); /* XXX */
-        }
-        ++n_segs;
-
-        seg_space = module->max_chunk_payload;
-        copyptr = seg->ss_base.us_payload.raw;
-
-        if (first_pass) {
-            /* logic could accommodate >max, but currently doesn't */
-            assert(reserve_len <= module->max_chunk_payload);
-            ret_ptr = copyptr;
-            seg_space -= reserve_len;
-            copyptr += reserve_len;
-        }
-
-        /* now pack any convertor data */
-        if (*convertor_bytes_packed < max_convertor_bytes && seg_space > 0) {
-            copylen = max_convertor_bytes - *convertor_bytes_packed;
-            if (copylen > seg_space) {
-                copylen = seg_space;
-            }
-            usnic_convertor_pack_simple(convertor, copyptr, copylen, &max_data);
-            seg_space -= max_data;
-            *convertor_bytes_packed += max_data;
-
-            /* If unable to pack any of the remaining bytes, release the
-            * most recently allocated segment and finish processing.
-            */
-            if (seg_space == module->max_chunk_payload) {
-                assert(max_data == 0); /* only way this can happen */
-                opal_btl_usnic_chunk_segment_return(module, seg);
-                break;
-            }
-        }
-
-        /* bozo checks */
-        assert(seg_space >= 0);
-        assert(seg_space < module->max_chunk_payload);
-
-        /* append segment of data to chain to send */
-        seg->ss_parent_frag = &lfrag->lsf_base;
-        seg->ss_len = module->max_chunk_payload - seg_space;
-        opal_list_append(&lfrag->lsf_seg_chain, &seg->ss_base.us_list.super);
-
-#if MSGDEBUG1
-        opal_output(0, "%s: appending seg=%p, frag=%p, payload=%zd\n",
-                    __func__, (void *)seg, (void *)lfrag,
-                    (module->max_chunk_payload - seg_space));
-#endif
-
-        first_pass = false;
-    }
-
-    return ret_ptr;
-}
-
-/* Responsible for handling "large" frags (reserve + *size > max_frag_payload)
- * in the same manner as btl_prepare_src.  Must return a smaller amount than
- * requested if the given convertor cannot process the entire (*size).
- */
-static
-opal_btl_usnic_send_frag_t *
-prepare_src_large(
-    struct opal_btl_usnic_module_t* module,
-    struct mca_btl_base_endpoint_t* endpoint,
-    struct opal_convertor_t* convertor,
-    uint8_t order,
-    size_t reserve,
-    size_t* size,
-    uint32_t flags)
-{
-    opal_btl_usnic_send_frag_t *frag;
-    opal_btl_usnic_large_send_frag_t *lfrag;
-    int rc;
-
-    /* Get holder for the msg */
-    lfrag = opal_btl_usnic_large_send_frag_alloc(module);
-    if (OPAL_UNLIKELY(NULL == lfrag)) {
-        return NULL;
-    }
-    frag = &lfrag->lsf_base;
-
-    /* The header location goes in SG[0], payload in SG[1].  If we are using a
-     * convertor then SG[1].seg_len is accurate but seg_addr is NULL. */
-    frag->sf_base.uf_base.USNIC_SEND_LOCAL_COUNT = 2;
-
-    /* stash header location, PML will write here */
-    frag->sf_base.uf_local_seg[0].seg_addr.pval = &lfrag->lsf_ompi_header;
-    frag->sf_base.uf_local_seg[0].seg_len = reserve;
-    /* make sure upper header small enough */
-    assert(reserve <= sizeof(lfrag->lsf_ompi_header));
-
-    if (OPAL_UNLIKELY(opal_convertor_need_buffers(convertor))) {
-        /* threshold == -1 means always pack eagerly */
-        if (mca_btl_usnic_component.pack_lazy_threshold >= 0 &&
-            *size >= (size_t)mca_btl_usnic_component.pack_lazy_threshold) {
-            MSGDEBUG1_OUT("packing frag %p on the fly", (void *)frag);
-            lfrag->lsf_pack_on_the_fly = true;
-
-            /* tell the PML we will absorb as much as possible while still
-             * respecting indivisible element boundaries in the convertor */
-            *size = opal_btl_usnic_convertor_pack_peek(convertor, *size);
-
-            /* Clone the convertor b/c we (the BTL) don't own it and the PML
-             * might mutate it after we return from this function. */
-            rc = opal_convertor_clone(convertor, &frag->sf_convertor,
-                                      /*copy_stack=*/true);
-            if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
-                BTL_ERROR(("unexpected convertor clone error"));
-                abort(); /* XXX */
-            }
-        }
-        else {
-            /* pack everything in the convertor into a chain of segments now,
-             * leaving space for the PML header in the first segment */
-            lfrag->lsf_base.sf_base.uf_local_seg[0].seg_addr.pval =
-                pack_chunk_seg_chain_with_reserve(module, lfrag, reserve,
-                                                  convertor, *size, size);
-        }
-
-        /* We set SG[1] to {NULL,bytes_packed} so that various calculations
-         * by both PML and this BTL will be correct.  For example, the PML adds
-         * up the bytes in the descriptor segments to determine if an MPI-level
-         * request is complete or not. */
-        frag->sf_base.uf_local_seg[1].seg_addr.pval = NULL;
-        frag->sf_base.uf_local_seg[1].seg_len = *size;
-    } else {
-        /* convertor not needed, just save the payload pointer in SG[1] */
-        lfrag->lsf_pack_on_the_fly = true;
-        opal_convertor_get_current_pointer(convertor,
-                                           &frag->sf_base.uf_local_seg[1].seg_addr.pval);
-        frag->sf_base.uf_local_seg[1].seg_len = *size;
-    }
-
-    frag->sf_base.uf_base.des_flags = flags;
-    frag->sf_endpoint = endpoint;
-
-    return frag;
-}
-
-
-/*
- * BTL 3.0 prepare_src function.
- *
- * This function is only used for sending PML fragments (not putting
- * or getting fragments).
- *
- * Note the "user" data the PML wishes to communicate and return a
- * descriptor.  We create a frag (which is also a descriptor by virtue
- * of its base class) and populate it with enough source information
- * to complete a future send.
- *
- * Recall that the usnic BTL's max_send_size is almost certainly
- * larger than the MTU (by default, max_send_size is either 25K or
- * 150K).  Therefore, the PML may give us a fragment up to
- * max_send_size in this function.  Hence, we make the decision here
- * as to whether it's a "small" fragment (i.e., size <= MTU, meaning
- * that it fits in a single datagram) or a "large" fragment (i.e.,
- * size > MTU, meaning that it must be chunked into multiple
- * datagrams).
- *
- * The convertor will be saved for deferred packing if the user buffer
- * is noncontiguous.  Otherwise, it will be saved in one of the
- * descriptor's SGEs.
- *
- * NOTE that the *only* reason this routine is allowed to return a size smaller
- * than was requested is if the convertor cannot process the entire amount.
- */
-static struct mca_btl_base_descriptor_t *
-usnic_prepare_src(struct mca_btl_base_module_t *base_module,
-                  struct mca_btl_base_endpoint_t *endpoint,
-                  struct opal_convertor_t *convertor,
-                  uint8_t order,
-                  size_t reserve,
-                  size_t *size,
-                  uint32_t flags)
-{
-    opal_btl_usnic_module_t *module = (opal_btl_usnic_module_t*) base_module;
-    opal_btl_usnic_send_frag_t *frag;
-    uint32_t payload_len;
-#if MSGDEBUG2
-    size_t osize = *size;
-#endif
-
-    /* Do we need to check the connectivity?  If enabled, we'll check
-       the connectivity at either first send to peer X or first ACK to
-       peer X. */
-    opal_btl_usnic_check_connectivity(module, endpoint);
-
-    /*
-     * if total payload len fits in one MTU use small send, else large
-     */
-    payload_len = *size + reserve;
-    if (payload_len <= module->max_frag_payload) {
-        frag = prepare_src_small(module, endpoint, convertor,
-                                 order, reserve, size, flags);
-    } else {
-        frag = prepare_src_large(module, endpoint, convertor,
-                                 order, reserve, size, flags);
-    }
-
-#if MSGDEBUG2
-    opal_output(0, "prep_src: %s %s frag %p, size=%d+%u (was %u), conv=%p\n",
-                module->fabric_info->fabric_attr->name,
-                (reserve + *size) <= module->max_frag_payload?"small":"large",
-                (void *)frag, (int)reserve, (unsigned)*size, (unsigned)osize,
-                (void *)convertor);
-#if MSGDEBUG1
-    {
-        unsigned i;
-        mca_btl_base_descriptor_t *desc = &frag->sf_base.uf_base;
-        for (i=0; i<desc->USNIC_SEND_LOCAL_COUNT; ++i) {
-            opal_output(0, "  %d: ptr:%p len:%d\n", i,
-                        (void *)desc->USNIC_SEND_LOCAL[i].seg_addr.pval,
-                        desc->USNIC_SEND_LOCAL[i].seg_len);
-        }
-    }
-#endif
-#endif
-
-    return &frag->sf_base.uf_base;
-}
-
-/*
- * Emulate an RDMA put.  We'll send the remote address across to the
- * other side so it will know where to put the data.
- *
- * Note that this function is only ever called with contiguous
- * buffers, so a convertor is not necessary.
- */
-static int
-usnic_put(struct mca_btl_base_module_t *base_module,
-          struct mca_btl_base_endpoint_t *endpoint,
-          void *local_address, uint64_t remote_address,
-          struct mca_btl_base_registration_handle_t *local_handle,
-          struct mca_btl_base_registration_handle_t *remote_handle,
-          size_t size, int flags, int order,
-          mca_btl_base_rdma_completion_fn_t cbfunc,
-          void *cbcontext, void *cbdata)
-{
-    opal_btl_usnic_send_frag_t *sfrag;
-    opal_btl_usnic_module_t *module = (opal_btl_usnic_module_t*) base_module;
-
-    /* At least for the moment, continue to make a descriptor, like we
-       used to in BTL 2.0 */
-    if (size <= module->max_frag_payload) {
-        /* Small send fragment -- the whole thing fits in one MTU
-           (i.e., a single chunk) */
-        opal_btl_usnic_small_send_frag_t *ssfrag;
-        ssfrag = opal_btl_usnic_small_send_frag_alloc(module);
-        if (OPAL_UNLIKELY(NULL == ssfrag)) {
-            return OPAL_ERR_OUT_OF_RESOURCE;
-        }
-
-        sfrag = &ssfrag->ssf_base;
-    } else {
-        /* Large send fragment -- need more than one MTU (i.e.,
-           multiple chunks) */
-        opal_btl_usnic_large_send_frag_t *lsfrag;
-        lsfrag = opal_btl_usnic_large_send_frag_alloc(module);
-        if (OPAL_UNLIKELY(NULL == lsfrag)) {
-            return OPAL_ERR_OUT_OF_RESOURCE;
-        }
-
-        lsfrag->lsf_pack_on_the_fly = true;
-
-        sfrag = &lsfrag->lsf_base;
-    }
-
-    sfrag->sf_endpoint = endpoint;
-    sfrag->sf_size = size;
-    sfrag->sf_ack_bytes_left = size;
-
-    opal_btl_usnic_frag_t *frag;
-    frag = &sfrag->sf_base;
-    frag->uf_local_seg[0].seg_len = size;
-    frag->uf_local_seg[0].seg_addr.pval = local_address;
-    frag->uf_remote_seg[0].seg_len = size;
-    frag->uf_remote_seg[0].seg_addr.pval =
-        (void *)(uintptr_t) remote_address;
-
-    mca_btl_base_descriptor_t *desc;
-    desc = &frag->uf_base;
-    desc->des_segment_count = 1;
-    desc->des_segments = &frag->uf_local_seg[0];
-    /* This is really the wrong cbfunc type, but we'll cast it to
-       the Right type before we use it.  So it'll be ok. */
-    desc->des_cbfunc = (mca_btl_base_completion_fn_t) cbfunc;
-    desc->des_cbdata = cbdata;
-    desc->des_context = cbcontext;
-    desc->des_flags = flags;
-    desc->order = order;
-
-    int rc;
-    rc = opal_btl_usnic_finish_put_or_send(module,
-                                           (opal_btl_usnic_endpoint_t *)endpoint,
-                                           sfrag,
-                                           /*tag=*/MCA_BTL_NO_ORDER);
-    return rc;
 }
 
 static int usnic_finalize(struct mca_btl_base_module_t* btl)
@@ -1544,7 +1114,7 @@ usnic_send(
     assert(frag->sf_endpoint == endpoint);
     frag->sf_base.uf_remote_seg[0].seg_addr.pval = NULL;      /* not a PUT */
 
-    compute_sf_size(frag);
+    opal_btl_usnic_compute_sf_size(frag);
     frag->sf_ack_bytes_left = frag->sf_size;
 
 #if MSGDEBUG2
@@ -2218,8 +1788,12 @@ static void init_pml_values(opal_btl_usnic_module_t *module)
     /* Since we emulate PUT, max_send_size can be same as
        eager_limit */
     module->super.btl_max_send_size =
-        module->super.btl_put_limit =
         module->super.btl_eager_limit;
+
+#if BTL_VERSION == 30
+    module->super.btl_put_limit =
+        module->super.btl_eager_limit;
+#endif
 }
 
 static void init_senders(opal_btl_usnic_module_t *module)
@@ -2603,11 +2177,10 @@ opal_btl_usnic_module_t opal_btl_usnic_module_template = {
     .super = {
         .btl_component = &mca_btl_usnic_component.super,
 
-        .btl_exclusivity = MCA_BTL_EXCLUSIVITY_DEFAULT,
-        .btl_flags =
-            MCA_BTL_FLAGS_SEND |
-            MCA_BTL_FLAGS_PUT |
-            MCA_BTL_FLAGS_SEND_INPLACE,
+#if BTL_VERSION == 20
+        .btl_prepare_dst = opal_btl_usnic_prepare_dst,
+        .btl_seg_size = sizeof(mca_btl_base_segment_t),
+#elif BTL_VERSION == 30
         .btl_atomic_flags = 0,
         .btl_registration_handle_size = 0,
 
@@ -2616,6 +2189,17 @@ opal_btl_usnic_module_t opal_btl_usnic_module_template = {
         .btl_put_limit = 0,
         .btl_put_alignment = 0,
 
+        .btl_atomic_op = NULL,
+        .btl_atomic_fop = NULL,
+        .btl_atomic_cswap = NULL,
+#endif
+
+        .btl_exclusivity = MCA_BTL_EXCLUSIVITY_DEFAULT,
+        .btl_flags =
+            MCA_BTL_FLAGS_SEND |
+            MCA_BTL_FLAGS_PUT |
+            MCA_BTL_FLAGS_SEND_INPLACE,
+
         .btl_add_procs = usnic_add_procs,
         .btl_del_procs = usnic_del_procs,
         .btl_register = NULL,
@@ -2623,16 +2207,12 @@ opal_btl_usnic_module_t opal_btl_usnic_module_template = {
 
         .btl_alloc = usnic_alloc,
         .btl_free = usnic_free,
-        .btl_prepare_src = usnic_prepare_src,
+        .btl_prepare_src = opal_btl_usnic_prepare_src,
         .btl_send = usnic_send,
         .btl_sendi = NULL,
-        .btl_put = usnic_put,
+        .btl_put = opal_btl_usnic_put,
         .btl_get = NULL,
         .btl_dump = mca_btl_base_dump,
-
-        .btl_atomic_op = NULL,
-        .btl_atomic_fop = NULL,
-        .btl_atomic_cswap = NULL,
 
         .btl_mpool = NULL,
         .btl_register_error = usnic_register_pml_err_cb,

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -1698,13 +1698,13 @@ static int usnic_sendi(struct mca_btl_base_module_t* btl,
  * RDMA Memory Pool (de)register callbacks
  */
 static int usnic_reg_mr(void* reg_data, void* base, size_t size,
-                          mca_mpool_base_registration_t* reg)
+                        mca_mpool_base_registration_t* reg)
 {
     opal_btl_usnic_module_t* mod = (opal_btl_usnic_module_t*)reg_data;
-    opal_btl_usnic_reg_t* ud_reg = (opal_btl_usnic_reg_t*)reg;
+    opal_btl_usnic_reg_t* ur = (opal_btl_usnic_reg_t*)reg;
     int rc;
 
-    rc = fi_mr_reg(mod->domain, base, size, 0, 0, 0, 0, &ud_reg->mr, NULL);
+    rc = fi_mr_reg(mod->domain, base, size, 0, 0, 0, 0, &ur->ur_mr, NULL);
     if (0 != rc) {
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
@@ -1712,21 +1712,20 @@ static int usnic_reg_mr(void* reg_data, void* base, size_t size,
     return OPAL_SUCCESS;
 }
 
-
 static int usnic_dereg_mr(void* reg_data,
-                            mca_mpool_base_registration_t* reg)
+                          mca_mpool_base_registration_t* reg)
 {
-    opal_btl_usnic_reg_t* ud_reg = (opal_btl_usnic_reg_t*)reg;
+    opal_btl_usnic_reg_t* ur = (opal_btl_usnic_reg_t*)reg;
 
-    if (ud_reg->mr != NULL) {
-        if (0 != fi_close(&ud_reg->mr->fid)) {
+    if (ur->ur_mr != NULL) {
+        if (0 != fi_close(&ur->ur_mr->fid)) {
             opal_output(0, "%s: error unpinning USD memory mr=%p: %s\n",
-                        __func__, (void*) ud_reg->mr, strerror(errno));
+                        __func__, (void*) ur->ur_mr, strerror(errno));
             return OPAL_ERROR;
         }
     }
 
-    ud_reg->mr = NULL;
+    ur->ur_mr = NULL;
     return OPAL_SUCCESS;
 }
 

--- a/opal/mca/btl/usnic/btl_usnic_send.c
+++ b/opal/mca/btl/usnic/btl_usnic_send.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
- * Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -106,7 +106,8 @@ opal_btl_usnic_chunk_send_complete(opal_btl_usnic_module_t *module,
  * This routine lives in this file to help prevent automatic inlining by the
  * compiler.
  *
- * The "tag" only applies to sends. */
+ * The "tag" only applies to sends.
+ */
 int
 opal_btl_usnic_finish_put_or_send(
     opal_btl_usnic_module_t *module,


### PR DESCRIPTION
@hjelmn I'm filing this as a pull request as a way to ask your opinion of how I did this.  There's several commits here, in order to break these up into smaller, easier-to-read changes:
1. btl.h doc changes. You already saw these.
2. btl.h whitespace cleanup.  No other changes.
3. Trivial usnic btl change; not related to BTL 3.0.
4. Just adding some comments to usnic BTL.
5. Update usnic README for BTL 3.0.
6. The actual BTL 3.0 changes for usnic (commit abb5649).
7. The last commit probably doesn't interest you: it restores compatibility between master and the v1.8 branch for the usnic BTL.  It's mainly code shuffling; there's very little new actual code here (code moved from module.c to compat.h and compat.c, and they're delimited with `#if BTL_VERSION==20/30`, etc.).

The real meat of the BTL 3.0 upgrade is in the abb5649 commit of this PR.

Could you have a look?

Thank you!
