### PR TITLE
usnic: update for dynamic add_procs() capability

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic_compat.c
+++ b/opal/mca/btl/usnic/btl_usnic_compat.c
@@ -64,6 +64,16 @@ uint64_t usnic_compat_rte_hash_name(opal_process_name_t *pname)
     return name;
 }
 
+/* This is techinically not a "compat" function -- it does not exist
+   in <v2.0.  It is here solely as a counterpart to the
+   usnic_compat_rte_hash_name(), above. */
+void usnic_compat_rte_unhash_name(uint64_t hashed_name,
+                                  opal_process_name_t *pname)
+{
+    pname->jobid = (hashed_name >> 32);
+    pname->vpid = (hashed_name & 0xffffffff);
+}
+
 const char *usnic_compat_proc_name_print(opal_process_name_t *pname)
 {
     return OPAL_NAME_PRINT(*pname);

--- a/opal/mca/btl/usnic/btl_usnic_compat.h
+++ b/opal/mca/btl/usnic/btl_usnic_compat.h
@@ -325,6 +325,10 @@ opal_btl_usnic_put(
 
 #include "opal/mca/btl/btl.h"
 
+void usnic_compat_rte_unhash_name(uint64_t hashed_name,
+                                  opal_process_name_t *pname);
+
+
 /* This function changed signature compared to BTL 2.0 */
 struct mca_btl_base_descriptor_t *
 opal_btl_usnic_prepare_src(struct mca_btl_base_module_t *base_module,

--- a/opal/mca/btl/usnic/btl_usnic_endpoint.c
+++ b/opal/mca/btl/usnic/btl_usnic_endpoint.c
@@ -13,7 +13,7 @@
  *                         reserved.
  * Copyright (c) 2007      The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2013-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
@@ -55,6 +55,7 @@ static void endpoint_construct(mca_btl_base_endpoint_t* endpoint)
     endpoint->endpoint_exiting = false;
     endpoint->endpoint_connectivity_checked = false;
     endpoint->endpoint_on_all_endpoints = false;
+    endpoint->num_fiavins_to_reap = 0;
 
     for (i = 0; i < USNIC_NUM_CHANNELS; ++i) {
         endpoint->endpoint_remote_modex.ports[i] = 0;

--- a/opal/mca/btl/usnic/btl_usnic_endpoint.h
+++ b/opal/mca/btl/usnic/btl_usnic_endpoint.h
@@ -178,6 +178,10 @@ typedef struct mca_btl_base_endpoint_t {
 
     bool endpoint_connectivity_checked;
     bool endpoint_on_all_endpoints;
+
+    /* Number of pending fi_av_inserts() that are running / need to be
+       reaped from this endpoint */
+    int num_fiavins_to_reap;
 } mca_btl_base_endpoint_t;
 
 typedef mca_btl_base_endpoint_t opal_btl_usnic_endpoint_t;

--- a/opal/mca/btl/usnic/btl_usnic_proc.c
+++ b/opal/mca/btl/usnic/btl_usnic_proc.c
@@ -743,13 +743,14 @@ opal_btl_usnic_create_endpoint(opal_btl_usnic_module_t *module,
     endpoint->endpoint_remote_modex = proc->proc_modex[modex_index];
 
     /* Start creating destinations; one for each channel.  These
-       progress in the background.a */
+       progress in the background. */
     for (int i = 0; i < USNIC_NUM_CHANNELS; ++i)  {
         rc = start_av_insert(module, endpoint, i);
         if (OPAL_SUCCESS != rc) {
             OBJ_RELEASE(endpoint);
             return rc;
         }
+        ++endpoint->num_fiavins_to_reap;
     }
 
     /* Initialize endpoint sequence number info */

--- a/opal/mca/btl/usnic/btl_usnic_recv.c
+++ b/opal/mca/btl/usnic/btl_usnic_recv.c
@@ -337,8 +337,12 @@ void opal_btl_usnic_recv_call(opal_btl_usnic_module_t *module,
         ++module->stats.num_ack_recvs;
 
 #if MSGDEBUG1
-        opal_output(0, "    Received ACK for sequence number %" UDSEQ " from %s to %s\n",
-                    bseg->us_btl_header->ack_seq, remote_ip, local_ip);
+        opal_output(0, "    Received ACK for sequence number %" UDSEQ " from %s:%u to %s:%u, module %p endpoint %p\n",
+                    bseg->us_btl_header->ack_seq,
+                    remote_ip, endpoint->endpoint_remote_modex.ports[0],
+                    local_ip, module->local_modex.ports[0],
+                    (void*) module,
+                    (void*) endpoint);
 #endif
         opal_btl_usnic_handle_ack(endpoint, ack_seq);
 


### PR DESCRIPTION
With this branch, I get PMIX warnings, however:

``` shell
$ mpirun --mca mpi_add_procs_cutoff 0 --mca btl usnic,sm,self ring_c 
[ivy02:19719] PMIX ERROR: BAD-PARAM in file src/buffer_ops/copy.c at line 38
[ivy02:19719] PMIX ERROR: BAD-PARAM in file src/client/pmix_client_get.c at line 315
...
[...ring runs normally and completes...]
```
