### PR TITLE
sessions: fix a problem with fortran comm handles

### DIFF
--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -22,7 +22,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
- * Copyright (c) 2018      Triad National Security, LLC. All rights
+ * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -49,6 +49,7 @@
 #include "ompi/dpm/dpm.h"
 #include "ompi/memchecker.h"
 #include "ompi/instance/instance.h"
+#include "ompi/mpi/fortran/use-mpi-f08/constants.h"
 
 /*
 ** Table for Fortran <-> C communicator handle conversion
@@ -109,6 +110,31 @@ int ompi_comm_init(void)
     OBJ_CONSTRUCT(&ompi_comm_f_to_c_table, opal_pointer_array_t);
     if( OPAL_SUCCESS != opal_pointer_array_init (&ompi_comm_f_to_c_table, 8,
                                                  OMPI_FORTRAN_HANDLE_MAX, 32) ) {
+        return OMPI_ERROR;
+    }
+
+    /*
+     * reserve indices in the F to C table for:
+     * MPI_COMM_WORLD
+     * MPI_COMM_SELF
+     * MPI_COMM_NULL
+     */
+
+    if (OPAL_SUCCESS != opal_pointer_array_set_item(&ompi_comm_f_to_c_table,
+                                                      OMPI_MPI_COMM_NULL,
+                                                      (void *)-1L)) {
+        return OMPI_ERROR;
+    }
+
+    if (OPAL_SUCCESS != opal_pointer_array_set_item(&ompi_comm_f_to_c_table,
+                                                      OMPI_MPI_COMM_WORLD,
+                                                      (void *)-1L)) {
+        return OMPI_ERROR;
+    }
+
+    if (OPAL_SUCCESS != opal_pointer_array_set_item(&ompi_comm_f_to_c_table,
+                                                      OMPI_MPI_COMM_SELF,
+                                                      (void *)-1L)) {
         return OMPI_ERROR;
     }
 
@@ -380,7 +406,7 @@ static int ompi_comm_finalize (void)
 
 static void ompi_comm_construct(ompi_communicator_t* comm)
 {
-    comm->c_f_to_c_index = opal_pointer_array_add(&ompi_comm_f_to_c_table, comm);
+    int idx;
     comm->c_name[0]      = '\0';
     comm->c_index        = MPI_UNDEFINED;
     comm->c_flags        = 0;
@@ -392,6 +418,20 @@ static void ompi_comm_construct(ompi_communicator_t* comm)
     comm->c_pml_comm     = NULL;
     comm->c_topo         = NULL;
     comm->c_coll         = NULL;
+
+    /*
+     * magic numerology - see TOPDIR/ompi/include/mpif-values.pl
+     */
+    idx = (comm == ompi_mpi_comm_world_addr) ? OMPI_MPI_COMM_WORLD :
+              (comm == ompi_mpi_comm_self_addr) ? OMPI_MPI_COMM_SELF :
+                  (comm == ompi_mpi_comm_null_addr) ? OMPI_MPI_COMM_NULL : -1;
+    if (-1 == idx) {
+        comm->c_f_to_c_index = opal_pointer_array_add(&ompi_comm_f_to_c_table,
+                                                      comm);
+    } else {
+        opal_pointer_array_set_item(&ompi_comm_f_to_c_table, idx, comm);
+        comm->c_f_to_c_index = idx;
+    }
 
     /* A keyhash will be created if/when an attribute is cached on
        this communicator */

--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -183,7 +183,7 @@ int ompi_comm_init_mpi3 (void)
 
     /* Setup MPI_COMM_WORLD */
     OBJ_CONSTRUCT(&ompi_mpi_comm_world, ompi_communicator_t);
-    assert(ompi_mpi_comm_world.comm.c_f_to_c_index == 1);
+    assert(ompi_mpi_comm_world.comm.c_f_to_c_index == OMPI_MPI_COMM_WORLD);
 
     ret = ompi_group_from_pset (ompi_mpi_instance_default, "mpi://world", &group);
     if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
@@ -237,7 +237,7 @@ int ompi_comm_init_mpi3 (void)
     }
     /* Setup MPI_COMM_SELF */
     OBJ_CONSTRUCT(&ompi_mpi_comm_self, ompi_communicator_t);
-    assert(ompi_mpi_comm_self.comm.c_f_to_c_index == 2);
+    assert(ompi_mpi_comm_self.comm.c_f_to_c_index == OMPI_MPI_COMM_SELF);
 
     ret = ompi_group_from_pset (ompi_mpi_instance_default, "mpi://self", &group);
     if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -1705,7 +1705,7 @@ OMPI_DECLSPEC  int MPI_Session_create_keyval (MPI_Session_delete_attr_function *
 OMPI_DECLSPEC  int MPI_Session_delete_attr (MPI_Session session, int session_keyval);
 OMPI_DECLSPEC  int MPI_Session_finalize (MPI_Session *session);
 OMPI_DECLSPEC  int MPI_Session_free_keyval(int *session_keyval);
-OMPI_DECLSPEC  int MPI_Session_get_attr (MPI_Session datatype, int session_keyval,
+OMPI_DECLSPEC  int MPI_Session_get_attr (MPI_Session session, int session_keyval,
                                          void *attribute_val, int *flag);
 OMPI_DECLSPEC  int MPI_Session_get_info (MPI_Session session, MPI_Info *info_used);
 OMPI_DECLSPEC  int MPI_Session_get_num_psets (MPI_Session session, int *npset_names);

--- a/ompi/mca/pml/ob1/pml_ob1_comm.c
+++ b/ompi/mca/pml/ob1/pml_ob1_comm.c
@@ -133,7 +133,7 @@ mca_pml_ob1_comm_proc_t *mca_pml_ob1_peer_create (ompi_communicator_t *comm, mca
     /* make sure proc structure is filled in before adding it to the array */
     opal_atomic_wmb ();
 
-    if (!OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_PTR((atomic_intptr_t *) pml_comm->procs + rank, &old_proc,
+    if (!OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_PTR((opal_atomic_intptr_t *) pml_comm->procs + rank, &old_proc,
 						(uintptr_t) proc)) {
 	/* proc was created by a competing thread. go ahead and throw this one away. */
 	OBJ_RELEASE(proc);

--- a/opal/mca/btl/vader/btl_vader_fifo.h
+++ b/opal/mca/btl/vader/btl_vader_fifo.h
@@ -203,7 +203,9 @@ static inline bool vader_fifo_write_ep (mca_btl_vader_hdr_t *hdr, struct mca_btl
         opal_atomic_wmb ();
         return mca_btl_vader_fbox_sendi (ep, 0xfe, &rhdr, sizeof (rhdr), NULL, 0);
     }
+#if 0
     mca_btl_vader_try_fbox_setup (ep, hdr);
+#endif
     hdr->next = VADER_FIFO_FREE;
     vader_fifo_write (ep->fifo, rhdr);
 


### PR DESCRIPTION
Sessions related changes changed the order of initialization
of pre-defined communicators used in the World Process Model.

This led to issues for MPI Fortran applications since the predefined
handles for MPI_COMM_WORLD, MPI_COMM_SELF, and MPI_COMM_NULL were
wrong, leading to a meltdown with any call to MPI using communicators
from the Fortran interfaces.

Further, when using sessions, there's no guarantee when the app might
finally call MPI_Init, so the original algorithm for adding entries
to the comm struct f_to_c pointer array no longer works as-is.

This commit fixes these issues with Fortran interfaces and MPI
communicator handles.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>